### PR TITLE
Multi target and friends - block-srTakeover and saphanasr-toolset

### DIFF
--- a/SAPHana/bin/SAPHanaSR-showAttr
+++ b/SAPHana/bin/SAPHanaSR-showAttr
@@ -31,15 +31,19 @@ my %Global;
 my %HName;
 my %SName;
 my %GName;
+my %Resource;
+my %RName;
 my $help;
 my $version;
 my $cibFile="";
+my $format="tables";
 
 sub init()
 {
 	my $result = GetOptions ("sid=s" => \@sids,
 	                      "sort=s" => \$sortBy,
 	                      "cib=s" => \$cibFile,
+                              "format=s" => \$format,
                           "version" => \$version,
                           "help" => \$help,
 		 );
@@ -79,13 +83,14 @@ if ( 0 == @sids ) {
 foreach my $sid (@sids) {
     ( $sid, $ino ) = split(":", $sid);
     $sid=lc("$sid");
-    %Host=(); %HName=(); %Global=(); %GName=(); %Site=(); %SName=();
-    get_hana_attributes($sid, \%Host, \%HName, \%Global, \%GName, \%Site,   \%SName);
+    %Host=(); %HName=(); %Global=(); %GName=(); %Site=(); %SName=(); %Resource=(); %RName=();
+    get_hana_attributes($sid, \%Host, \%HName, \%Global, \%GName, \%Site,   \%SName, \%Resource, \%RName);
     if ( keys(%Host) == 0 ) {
         printf "No attributes found for SID=%s\n", $sid;
     } else {
-	    print_host_attr(\%Global, \%GName, "Global", "");
-	    print_host_attr(\%Site,   \%SName, "Sites",  "");
-        print_host_attr(\%Host,   \%HName, "Hosts",  $sortBy);
+	    print_host_attr(\%Global, \%GName, "Global", "", $format);
+	    print_host_attr(\%Resource, \%RName, "Resource", "", $format);
+	    print_host_attr(\%Site,   \%SName, "Sites",  "", $format);
+        print_host_attr(\%Host,   \%HName, "Hosts",  $sortBy, $format);
     }
 }

--- a/SAPHana/man/SAPHanaSR-ScaleOut.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut.7
@@ -1,6 +1,6 @@
 .\" Version: 0.170.0
 .\"
-.TH SAPHanaSR-ScaleOut 7 "18 Jun 2020" "" "SAPHanaSR-ScaleOut"
+.TH SAPHanaSR-ScaleOut 7 "14 Jul 2020" "" "SAPHanaSR-ScaleOut"
 .\"
 .SH NAME
 SAPHanaSR-ScaleOut \- Tools for automating SAP HANA system replication in
@@ -115,7 +115,10 @@ secondary after the primary landscape fails. The alternative is to restart the
 primary landscape, if it fails and only to take-over when no local restart is
 possible anymore. This can be tuned by SAPHanaController(7) parameters.
 .br
-Preferring take-over over local restart usually has been choosen for HANA system replication performance-optimised setups. On the other hand local restart of the master instead of take-over could be combined with HANA's persistent memory features.
+Preferring take-over over local restart usually has been choosen for HANA
+system replication performance-optimised setups. On the other hand local
+restart of the master instead of take-over could be combined with HANA's
+persistent memory features.
 .br
 The current implementation only allows to take-over in case the landscape status
 reports 1 (ERROR). The cluster will not take-over, when the SAP HANA still tries
@@ -128,8 +131,15 @@ the nameserver on another node. Therefore usually up to two nodes are
 configured as additional nameserver candidates. At least one of them should be
 a standby node to optimize failover time. The Linux cluster will detect the
 change and move the IP address to the new active master nameserver.
+This case fits for bigger scale-out HANAs, e.g. BW systems. 
 .PP
+6. \fBLocal stop of orphaned worker node\fR
+.br
+If the HANA master nameserver fails and can not be recoverd, the orphaned
+HANA worker will be stopped by the Linux cluster.
+This case fits for small scale-out HANAs, e.g. ERP systems with two nodes.
 .\" TODO scenario filesystem full or inaccesible: additional Filsystem RA
+.PP
 .\" 
 \fBImplementation\fR
 .PP
@@ -142,6 +152,8 @@ The HANA consists of two sites with same number of nodes each. There are no
 HANA nodes outside the Linux cluster. An additional Linux cluster node is used
 as majority maker for split-brain situations. This dedicated node does not need
 to have HANA installed and must not run any SAP HANA resources for the same SID.
+.PP
+The HANA HADR provider is used for detecting system replication status changes.
 .PP
 A common STONITH mechanism is set up for all nodes across all the sites.
 .PP
@@ -227,7 +239,7 @@ With the mentioned HANA versions uni-directional chained system replication
 is possible. Beginning with HANA 2.0 SPS 3 multi-target system replication
 is possible as well. Even in HANA multi-target environments, the current
 resource agent manages only two sites. Thus only two HANA sites are part
-of the Linux cluster. 
+of the Linux cluster. See also item 5 above.
 .\" TODO check HANA version for multi-target
 .\" TODO up to version 0.169 vs. version 0.170 and later
 .PP
@@ -247,7 +259,8 @@ Please report any other feedback and suggestions to feedback@suse.com.
 .PP
 .\"
 .SH SEE ALSO
-\fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHanaController\fP(7) , \fBocf_heartbeat_IPaddr2\fP(7) ,
+\fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHanaController\fP(7) ,
+\fBocf_heartbeat_IPaddr2\fP(7) , \fBSAPHanaSR-ScaleOut_basic_cluster\fP(7) ,
 \fBSAPHanaSR-monitor\fP(8) , \fBSAPHanaSR-showAttr\fP(8) , \fBSAPHanaSR.py\fP(7) , 
 \fBntp.conf\fP(5) , \fBstonith\fP(8) , \fBsbd\fP(8) , \fBstonith_sbd\fP(7) ,
 \fBcrm\fP(8) , \fBcorosync.conf\fP(5) , \fBcrm_no_quorum_policy\fP(7) ,

--- a/SAPHana/man/SAPHanaSR-ScaleOut.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut.7
@@ -228,7 +228,8 @@ is possible. Beginning with HANA 2.0 SPS 3 multi-target system replication
 is possible as well. Even in HANA multi-target environments, the current
 resource agent manages only two sites. Thus only two HANA sites are part
 of the Linux cluster. 
-.\" TODO: check HANA version for multi-target
+.\" TODO check HANA version for multi-target
+.\" TODO up to version 0.169 vs. version 0.170 and later
 .PP
 10. For scale-out, if the shared storage is implemented with another cluster,
 that one does not interfere with the Linux cluster. All three clusters

--- a/SAPHana/man/SAPHanaSR-ScaleOut.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut.7
@@ -135,8 +135,9 @@ This case fits for bigger scale-out HANAs, e.g. BW systems.
 .PP
 6. \fBLocal stop of orphaned worker node\fR
 .br
-If the HANA master nameserver fails and can not be recoverd, the orphaned
-HANA worker will be stopped by the Linux cluster.
+If the HANA master nameserver fails, the HANA landscape status goes to "ERROR",
+and HANA can not recover on its own, the orphaned HANA worker will be stopped
+by the Linux cluster.
 This case fits for small scale-out HANAs, e.g. ERP systems with two nodes.
 .\" TODO scenario filesystem full or inaccesible: additional Filsystem RA
 .PP

--- a/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -1,4 +1,4 @@
-.\" Version: 0.1i70.0
+.\" Version: 0.170.0
 .\"
 .TH SAPHanaSR-ScaleOut 7 "14 Jul 2020" "" "SAPHanaSR-ScaleOut_basic_cluster"
 .\"

--- a/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -193,7 +193,7 @@ primary and secondary master are in a certain range. The scores used by the
 Linux cluster should be in the same range.
 
 .br
-	# SAPHanaSR-showAttr | grep master1:master
+	# SAPHanaSR-showAttr | grep master.:master
 .br
 	# crm_simulate -Ls | grep promotion
 .RE

--- a/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
+++ b/SAPHana/man/SAPHanaSR-ScaleOut_basic_cluster.7
@@ -1,6 +1,6 @@
-.\" Version: 0.165.0
+.\" Version: 0.1i70.0
 .\"
-.TH SAPHanaSR-ScaleOut 7 "04 Jun 2020" "" "SAPHanaSR-ScaleOut_basic_cluster"
+.TH SAPHanaSR-ScaleOut 7 "14 Jul 2020" "" "SAPHanaSR-ScaleOut_basic_cluster"
 .\"
 .SH NAME
 SAP HANA System Replication scale-out basic cluster configuration.
@@ -24,16 +24,19 @@ case of quorum loss. With more than two nodes, the cluster must not ignore the
 quorum loss. For SAPHanaSR-ScaleOut, an odd number of nodes is required. Setting
 no-quorum-policy to 'freeze' won't allow the partition to shoot any other node
 when it doesn't have quorum. Cluster will not be able to add and start new resources,
-but unning will stay alive.
+but running will stay alive.
 If the cluster uses disk-less SBD, the no-quorum-policy 'suicide' is required. 
 
 \fBdefault-resource-stickiness = 1000\fR
 
-The crm basic parameter default-resource-stickiness defines the 'stickiness' score
-a resource gets on the node where it is currently running. This prevents
+The crm basic parameter default-resource-stickiness defines the 'stickiness'
+score a resource gets on the node where it is currently running. This prevents
 the cluster from moving resources around whithout an urgent need during a
-cluster transition. The correct value depends on number of resources and colocation
-rules. Too high value might prevent not only unwanted but also useful actions.
+cluster transition. The correct value depends on number of resources, colocation rules and resource groups. Particularly additional groups colocated to the
+HANA primary master resource can affect cluster decisions. 
+Too high value might prevent not only unwanted but also useful actions.
+This is because SAPHanaSR uses an internal scoring table for placing the HANA
+roles on the right nodes.
 
 \fBconcurrent-fencing = true\fR
 
@@ -153,6 +156,7 @@ property cib-bootstrap-options: \\
 .br
 rsc_defaults rsc-options: \\
 .br
+.\" TODO resource-stickiness=120 or 1000?
 	resource-stickiness=120 \\
 .br
 	migration-threshold=50 \\
@@ -173,13 +177,25 @@ op_defaults op-options: \\
 To complete the SBD setup, it is necessary to activate SBD as STONITH/fencing
 mechanism in the CIB. The SBD is normally used for SAPHanaSR-ScaleOut instead
 of any other fencing/stonith mechanism. Example for disk-based SBD:
-
 .PP
 .RS 4
 .br
 primitive rsc_stonith_sbd stonith:external/sbd \\
 .br
 	params pcmk_action_limit="-1" pcmk_delay_max="1"
+.RE
+.PP
+
+\fB* check how resource stickiness affects promotion scoring\fR
+
+SAPHanaSR uses an internal scoring table. The promotion scores for HANA
+primary and secondary master are in a certain range. The scores used by the
+Linux cluster should be in the same range.
+
+.br
+	# SAPHanaSR-showAttr | grep master1:master
+.br
+	# crm_simulate -Ls | grep promotion
 .RE
 .PP
 .\"
@@ -193,7 +209,7 @@ Please report any other feedback and suggestions to feedback@suse.com.
 \fBocf_suse_SAPHanaTopology\fP(7) , \fBocf_suse_SAPHanaController\fP(7) ,
 \fBsbd\fP(8) , \fBstonith_sbd\fP(7) , \fBcrm_no_quorum_policy\fP(7) ,
 \fBcrm\fP(8) , \fBcrm_simulate\fP(8) , \fBSAPHanaSR-ScaleOut\fP(7) ,
-\fBcorosync.conf\fP(5) , \fBvotequorum\fP(5) ,
+\fBSAPHanaSR-showAttr\fP(7) , \fBcorosync.conf\fP(5) , \fBvotequorum\fP(5) ,
 .br
 https://documentation.suse.com/sbp/all/?context=sles-sap ,
 .br

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -13,7 +13,8 @@ SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replica
 .SH DESCRIPTION
 SAPHanaSR-showAttr shows Linux cluster attributes for SAP HANA system replication automation.
 The overall system replication (SR) state is shown as well as the HANA state on each node.
-Because the HANA srHook methods srConnectionChanged() and preTakeover() are used, the respective information shows up as well.
+Because the HANA srHook methods srConnectionChanged() and preTakeover() are used, the respective
+information shows up as well.
 The information is fetched from the Linux cluster information base (CIB), not from HANA directly.
 .PP
 The output shows three sections, containing all or some of the listed fields:
@@ -255,7 +256,15 @@ The 4th value (PRIM) just indicates an HANA SR primary.
 
 Value: [ SOK | SFAIL | SWAIT | PRIM ]
 
-The cluster property hana_<sid>_site_srHook_<site> represents the HANA SR status from HA/DR provider API method srConnectionChanged().
+The cluster property related to srHook represents the HANA SR status from HA/DR provider
+API method srConnectionChanged(). Version 1.0 of that API supports only one system replication.
+Version 2.0 also supports multi-tier system replication.
+.br
+For SAPHanaSR-ScaleOut up to version 0.169 hana_<sid>_glob_srHook shows one HANA SR status. 
+For version 0.170 and later hana_<sid>_site_srHook_<site> shows the HANA SR status specific
+to the respective site.
+.br
+Note: Global and site-specific properties must not appear at same time.
 .PP
 .B version
 - HANA version

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -13,10 +13,8 @@ SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replica
 .SH DESCRIPTION
 SAPHanaSR-showAttr shows Linux cluster attributes for SAP HANA system replication automation.
 The overall system replication (SR) state is shown as well as the HANA state on each node.
-Because the HANA srHook method srConnectionChanged() is used, the respective information
-shows up as well.
-The information is fetched from the Linux cluster information base (CIB), not from HANA
-directly.
+Because the HANA srHook methods srConnectionChanged() and postTakeover() are used, the respective information shows up as well.
+The information is fetched from the Linux cluster information base (CIB), not from HANA directly.
 .PP
 The output shows three sections, containing all or some of the listed fields:
 .\" TODO check with existing script.
@@ -31,7 +29,7 @@ HANA primary replication site (\fBprim\fP)
 .br
 HANA secondary replication site (\fBsec\fP)
 .br
-HANA replication channel state indicated by srConnectionChanged (\fBsrHook\fP)
+HANA replication channel state, indicated by srConnectionChanged (\fBsrHook\fP)
 .br
 HANA replication state of secondary site, indicated by systemReplicationStatus.py (\fBsync_state\fP)
 .TP
@@ -70,7 +68,7 @@ HANA version (\fBversion\fP)
 .br
 HANA virtual host name (\fBvhost\fP)
 .br
-HANA system replication takeover action (\fBsra\fP)
+HANA system replication takeover action, indicated by postTakeover() (\fBsra\fP)
 .PP
 Some fields are generated dynamically from the CIB. That fields might be missing,
 if no corresponding attribute exists, e.g. the standby field.
@@ -257,8 +255,7 @@ The 4th value (PRIM) just indicates an HANA SR primary.
 
 Value: [ SOK | SFAIL | SWAIT | PRIM ]
 
-The cluster property hana_<sid>_site_srHook_<site> represents the HANA SR status from
-HA/DR provider API.
+The cluster property hana_<sid>_site_srHook_<site> represents the HANA SR status from HA/DR provider API method srConnectionChanged().
 .PP
 .B version
 - HANA version
@@ -289,7 +286,7 @@ hostname to the HANA virtual hostname.
 Value: [ T | R | - ]
 .\" TODO final values
 
-The node attribute system replication action is set by the HA/DR provider API.
+The node attribute system replication action is set by the HA/DR provider API method postTakeover().
 It indicates whether a take-over or registration is ongoing.
 .br
 T = Take-over on new primary (sr_takeover) ongoing.

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -1,6 +1,6 @@
 .\" Version: 0.170.0
 .\"
-.TH SAPHanaSR-showAttr 8 "02 Jul 2020" "" "SAPHanaSR-ScaleOut"
+.TH SAPHanaSR-showAttr 8 "14 Jul 2020" "" "SAPHanaSR-ScaleOut"
 .\"
 .SH NAME
 SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replication.
@@ -13,7 +13,7 @@ SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replica
 .SH DESCRIPTION
 SAPHanaSR-showAttr shows Linux cluster attributes for SAP HANA system replication automation.
 The overall system replication (SR) state is shown as well as the HANA state on each node.
-Because the HANA srHook methods srConnectionChanged() and postTakeover() are used, the respective information shows up as well.
+Because the HANA srHook methods srConnectionChanged() and preTakeover() are used, the respective information shows up as well.
 The information is fetched from the Linux cluster information base (CIB), not from HANA directly.
 .PP
 The output shows three sections, containing all or some of the listed fields:
@@ -68,7 +68,7 @@ HANA version (\fBversion\fP)
 .br
 HANA virtual host name (\fBvhost\fP)
 .br
-HANA system replication takeover action, indicated by postTakeover() (\fBsra\fP)
+HANA system replication takeover action, indicated by preTakeover() (\fBsra\fP)
 .PP
 Some fields are generated dynamically from the CIB. That fields might be missing,
 if no corresponding attribute exists, e.g. the standby field.
@@ -286,7 +286,7 @@ hostname to the HANA virtual hostname.
 Value: [ T | R | - ]
 .\" TODO final values
 
-The node attribute system replication action is set by the HA/DR provider API method postTakeover().
+The node attribute system replication action is set by the HA/DR provider API method preTakeover().
 It indicates whether a take-over or registration is ongoing.
 .br
 T = Take-over on new primary (sr_takeover) ongoing.
@@ -335,6 +335,9 @@ show all SAPHanaSR attributes in the cluster and sort host table output by roles
 .TP
 # SAPHanaSR-showAttr --sid=HA1:10 --cib=./hb_report-17-07-2019/grauenstein01/cib.xml
 show all SAPHanaSR attributes for SAP iystem ID HA1 and instance number 10 from given CIB file.
+.TP
+# SAPHanaSR-showAttr | grep -e master: -e worker: -e slave:
+show SAPHanaSR promotion scores on running nodes. 
 .\"
 .SH FILES
 .TP
@@ -357,7 +360,7 @@ Feedback is welcome, please mail to feedback@suse.com.
 \fBocf_suse_SAPHanaController\fP(7) , \fBocf_suse_SAPHanaTopology\fP(7) ,
 \fBSAPHanaSR-ScaleOut\fP(7) , \fBSAPHanaSR-replay-archive\fP(8) , \fBSAPHanaSR-filter\fP(8) ,
 \fBSAPHanaSR-monitor\fP(8) , \fBSAPHanaSR_maintenance_examples\fP(7) ,
-\fBcrm_simulate\fP(8) , \fBcibadmin\fP(8) , \fBcrm_mon\fP(8) ,
+\fBcrm_simulate\fP(8) , \fBcibadmin\fP(8) , \fBcrm_mon\fP(8) , \fBcs_convert_time\fP(8) ,
 \fBcs_clusterstate\fP(8) , \fBcs_show_hana_info\fP(8) , \fBcs_show_scores\fP(8) ,
 .br
 https://documentation.suse.com/sbp/all/?context=sles-sap ,

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -239,8 +239,7 @@ This is a Linux Cluster node attribute. It is set by an admin.
 The attribute is shown after it has been changed from the default.
 The field might appear or disappear, depending on cluster maintenance tasks.
 .PP
-.B sync_st
-and \fBsync_state\fR
+.B sync_state
 - HANA SR status
 
 Value: [ SOK | SFAIL | SWAIT | PRIM ]

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -256,13 +256,11 @@ The 4th value (PRIM) just indicates an HANA SR primary.
 
 Value: [ SOK | SFAIL | SWAIT | PRIM ]
 
-The cluster property related to srHook represents the HANA SR status from HA/DR provider
-API method srConnectionChanged(). Version 1.0 of that API supports only one system replication.
-Version 2.0 also supports multi-tier system replication.
+The cluster property related to srHook represents the HANA SR status from HA/DR provider API method srConnectionChanged(). See SAPHanaSR-ScaleOut(7) for supported API versions and scenarios.
 .br
-For SAPHanaSR-ScaleOut up to version 0.169 hana_<sid>_glob_srHook shows one HANA SR status. 
-For version 0.170 and later hana_<sid>_site_srHook_<site> shows the HANA SR status specific
-to the respective site.
+The cluster property \fBhana_<sid>_glob_srHook\fR shows one HANA SR status. It does
+not work for multi-tier and multi-target system replication.
+\fBhana_<sid>_site_srHook_<site>\fR shows the HANA SR status specific to the respective site.
 .br
 Note: Global and site-specific properties must not appear at same time.
 .PP

--- a/SAPHana/man/SAPHanaSR-showAttr.8
+++ b/SAPHana/man/SAPHanaSR-showAttr.8
@@ -1,6 +1,6 @@
 .\" Version: 0.170.0
 .\"
-.TH SAPHanaSR-showAttr 8 "18 Jun 2020" "" "SAPHanaSR-ScaleOut"
+.TH SAPHanaSR-showAttr 8 "02 Jul 2020" "" "SAPHanaSR-ScaleOut"
 .\"
 .SH NAME
 SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replication.
@@ -9,7 +9,6 @@ SAPHanaSR-showAttr \- Shows Linux cluster attributes for SAP HANA system replica
 \fBSAPHanaSR-showAttr\fR [ --help | --version ]
 .br
 \fBSAPHanaSR-showAttr\fR [ --sid=SID[:INO] ] [ --sort=FIELD ] [ --format=FORMAT ] [ --cib=OFFLINE_CIB_FILE ]
-.\" TODO \fBSAPHanaSR-showAttr\fR [ --sid=SID[:INO]] [ --sort=FIELD ] [ --format=FORMAT ] [ --cib=OFFLINE_CIB_FILE ]
 .\"
 .SH DESCRIPTION
 SAPHanaSR-showAttr shows Linux cluster attributes for SAP HANA system replication automation.
@@ -61,15 +60,17 @@ actual master score on that node (\fBscore\fP)
 .br
 HANA site where the host sits (\fBsite\fP)
 .br
-HANA SR mode (\fBsrmode\fP)
+HANA system replication mode (\fBsrmode\fP)
 .br
 maintenance state of Linux cluster node (\fBstandby\fP)
 .br
-HANA SR status (\fBsync_state\fP)
+HANA system replication status (\fBsync_state\fP)
 .br
 HANA version (\fBversion\fP)
 .br
 HANA virtual host name (\fBvhost\fP)
+.br
+HANA system replication takeover action (\fBsra\fP)
 .PP
 Some fields are generated dynamically from the CIB. That fields might be missing,
 if no corresponding attribute exists, e.g. the standby field.
@@ -282,6 +283,21 @@ The attribute is used by the SAPHana orSAPHanaController  resource agent for set
 See also the  fields Hosts and remoteHost. SAPHanaToplogy needs the SAPHOSTAGENT to map from the local
 hostname to the HANA virtual hostname.
 .\" TODO details, see HANA global.ini
+.PP
+.B sra
+- HANA system replication action
+
+Value: [ T | R | - ]
+.\" TODO final values
+
+The node attribute system replication action is set by the HA/DR provider API.
+It indicates whether a take-over or registration is ongoing.
+.br
+T = Take-over on new primary (sr_takeover) ongoing.
+.br
+R = Registration on new secondary (sr_register) ongoing.
+.br
+- = No action pending.
 .\"
 .SH OPTIONS
 .HP

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -34,7 +34,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.170.3.0701.1549"
+SAPHanaControllerVersion="0.170.3.0713.1301"
 #
 # Initialization:
 timeB=$(date '+%s')

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -2683,39 +2683,68 @@ function saphana_monitor_clone() {
             fi
         fi
     else
+        #
+        # instance is not THE master nameserver
+        #
         nState=$(get_hana_attribute ${NODENAME} "${ATTR_NAME_HANA_CLONE_STATE[@]}")
         # TODO: PRIO2: Check, if we need to (re) start a failed SAP HANA instance in a swarm
         if ! saphana_check_local_instance; then
+            #
+            # local instance is not THE master nameserver and is currently stopped
+            #
             # IF LS>=2 AND ROLE STANDBY "RESTART" INSTANCE
             get_hana_landscape_status; lss=$?
             if [ $lss -gt 2 ]; then
-                case "$nState" in
-                    DEMOTED ) rc=$OCF_NOT_RUNNING;;      # landscape is up but local instance is down -> report NOT_RUNNING
-                    PROMOTED ) rc=$OCF_NOT_RUNNING;;     # same, but for MASTER -> report NOT_RUNNING
-                    UNDEFINED ) rc=$OCF_NOT_RUNNING;;    # same is DEMOTED, but target should be down -> report NOT_RUNNING
-                    * ) rc=$OCF_NOT_RUNNING;;
-                esac
+                rc=$OCF_NOT_RUNNING
             else
+                #
+                # local instance AND landscape are down - report NOT_RUNNING
+                #
                 case "$nState" in
-                    DEMOTED ) rc=$OCF_SUCCESS;;          # landscape is down and local instance is down -> report SUCCESS
-                    PROMOTED ) rc=$OCF_NOT_RUNNING;;     # same, but for MASTER -> report NOT_RUNNING
+                    DEMOTED ) rc=$OCF_SUCCESS;;          # landscape is up but local instance is down -> report OK
+                    PROMOTED ) rc=$OCF_FAILED_MASTER;;   # same, but for MASTER -> report FAILED_MASTER
                     UNDEFINED ) rc=$OCF_NOT_RUNNING;;    # same is DEMOTED, but target should be down -> report NOT_RUNNING
                     * ) rc=$OCF_NOT_RUNNING;;
                 esac
             fi
             #
         else
+            #
+            # local instance not THE master nameserver, but up-and-running
+            #
             super_ocf_log info "DEC: the_master=<<$the_master>>"
-            if [ is_active_nameserver_slave -a -z "$the_master" ]; then
-              #
-              # code for missing ALL master nameserver candidates
-              #
-              super_ocf_log info "DEC: left-over instance ???"
-              get_hana_landscape_status; lss=$?
-              if [ $lss -le 1 ]; then
-                 # we are a left-over sctive master nameserver nodes - report an error to the cluster to get this instance stopped
-                 rc=$OCF_NOT_RUNNING
-              fi
+            if [ -z "$the_master"  ]; then
+                #
+                # code for missing ALL master nameserver candidates
+                #
+                if is_active_nameserver_slave; then
+                    #
+                    # missing ALL master nameser candidates, but local instance still running -> we need to trigger the cluster to take us down
+                    #
+                    super_ocf_log info "DEC: left-over instance ???"
+                    get_hana_landscape_status; lss=$?
+                    if [ $lss -le 1 ]; then
+                        #
+                        # landscape alraedy reports down / error but local instance is up and running
+                        # we are a left-over active instance without master nameserver nodes - report an error to the cluster to get this instance stopped
+                        #
+                        super_ocf_log info "DEC: left-over instance and lss=$lss - report generic error for lost instance"
+                        rc=$OCF_ERR_GENERIC
+                    else
+                        #
+                        # landscape still reports a running swarm AND local instance is up and running
+                        # we are a left-over active instance without master nameserver nodes - wait till landscape status falls down to error
+                        #
+                        super_ocf_log info "DEC: left-over instance and lss=$lss - wait till lss falls down to error and SAP HANA did a final decission"
+                        rc=$OCF_SUCCESS
+                    fi
+                else
+                    #
+                    # missing ALL master nameser candidates AND local instance is also stopped -> just inform the cluster we are down
+                    #
+                    super_ocf_log info "DEC: left-over instance but already down"
+                    rc=$OCF_NOT_RUNNING
+                fi
             else
               #
               # code, if we still have ANY master nameserver candidates

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -34,7 +34,7 @@
 #     systemReplicationStatus.py (>= SPS090)
 #
 #######################################################################
-SAPHanaControllerVersion="0.170.3.0713.1301"
+SAPHanaControllerVersion="0.170.3.0713.1635"
 #
 # Initialization:
 timeB=$(date '+%s')
@@ -2695,16 +2695,26 @@ function saphana_monitor_clone() {
             # IF LS>=2 AND ROLE STANDBY "RESTART" INSTANCE
             get_hana_landscape_status; lss=$?
             if [ $lss -gt 2 ]; then
+                super_ocf_log info "DEC: local instance is down landscape is up (lss=$lss)"
                 rc=$OCF_NOT_RUNNING
             else
                 #
-                # local instance AND landscape are down - report NOT_RUNNING
+                # local instance AND landscape are down
                 #
+                super_ocf_log info "DEC: local instance AND landscape are down (lss=$lss)"
                 case "$nState" in
-                    DEMOTED ) rc=$OCF_SUCCESS;;          # landscape is up but local instance is down -> report OK
-                    PROMOTED ) rc=$OCF_FAILED_MASTER;;   # same, but for MASTER -> report FAILED_MASTER
-                    UNDEFINED ) rc=$OCF_NOT_RUNNING;;    # same is DEMOTED, but target should be down -> report NOT_RUNNING
-                    * ) rc=$OCF_NOT_RUNNING;;
+                    DEMOTED )
+                                super_ocf_log info "DEC: DEMOTED => OCF_SUCCESS"
+                                rc=$OCF_SUCCESS;;          # landscape is up but local instance is down -> report OK
+                    PROMOTED )
+                                super_ocf_log info "DEC: PROMOTED => OCF_FAILED_MASTER"
+                                rc=$OCF_FAILED_MASTER;;   # same, but for MASTER -> report FAILED_MASTER
+                    UNDEFINED )
+                                super_ocf_log info "DEC: UNDEFINED => OCF_NOT_RUNNING"
+                                rc=$OCF_NOT_RUNNING;;    # same is DEMOTED, but target should be down -> report NOT_RUNNING
+                    * )
+                                super_ocf_log info "DEC: <<UNKNOWN>> => OCF_NOT_RUNNING"
+                                rc=$OCF_NOT_RUNNING;;
                 esac
             fi
             #
@@ -2725,7 +2735,7 @@ function saphana_monitor_clone() {
                     get_hana_landscape_status; lss=$?
                     if [ $lss -le 1 ]; then
                         #
-                        # landscape alraedy reports down / error but local instance is up and running
+                        # landscape already reports down / error but local instance is up and running
                         # we are a left-over active instance without master nameserver nodes - report an error to the cluster to get this instance stopped
                         #
                         super_ocf_log info "DEC: left-over instance and lss=$lss - report generic error for lost instance"

--- a/SAPHana/ra/SAPHanaController
+++ b/SAPHana/ra/SAPHanaController
@@ -2579,7 +2579,7 @@ function saphana_monitor_secondary()
 #
 # function: saphana_monitor_clone - monitor a hana clone instance
 # params:   -
-# globals:  OCF_*, ATTR_NAME_*, HOSTNANE, HANA_STATE_*
+# globals:  OCF_*, ATTR_NAME_*, HOSTNAME, HANA_STATE_*
 # saphana_monitor_clone
 #
 function saphana_monitor_clone() {

--- a/SAPHana/srHook/SAPHanaSrMultiTarget.py
+++ b/SAPHana/srHook/SAPHanaSrMultiTarget.py
@@ -9,7 +9,7 @@ SAPHanaSR needs SAP HANA 2.0 SPS4 (2.00.040.00) as minimum version
 """
 import os, time
 
-fhSRHookVersion = "0.170.3.0706.1711"
+fhSRHookVersion = "0.170.3.0716.1509"
 
 try:
     from hdb_ha_dr.client import HADRBase
@@ -35,40 +35,40 @@ try:
         def __init__(self, *args, **kwargs):
             # delegate construction to base class
             super(SAPHanaSR, self).__init__(*args, **kwargs)
-            method="init"
-            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__,method,fhSRHookVersion))
+            method = "init"
+            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__, method, fhSRHookVersion))
 
         def about(self):
-            method="about"
-            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__,method,fhSRHookVersion))
+            method = "about"
+            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__, method, fhSRHookVersion))
             return {"provider_company": "SUSE",
                     "provider_name": "SAPHanaSR",  # class name
                     "provider_description": "Inform Cluster about SR state",
                     "provider_version": "1.0"}
 
         def startup(self, hostname, storage_partition, sr_mode, **kwargs):
-            method="startup"
+            method = "startup"
             self.tracer.debug("enter startup hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave startup hook")
             return 0
 
         def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
-            method="shutdown"
+            method = "shutdown"
             self.tracer.debug("enter shutdown hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave shutdown hook")
             return 0
 
         def failover(self, hostname, storage_partition, sr_mode, **kwargs):
-            method="failover"
+            method = "failover"
             self.tracer.debug("enter failover hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave failover hook")
             return 0
 
         def stonith(self, failingHost, **kwargs):
-            method="stonith"
+            method = "stonith"
             self.tracer.debug("enter stonith hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             # e.g. stonith of params["failed_host"]
@@ -78,7 +78,7 @@ try:
 
         def preTakeover(self, isForce, **kwargs):
             """Pre takeover hook."""
-            method="preTakeover"
+            method = "preTakeover"
             self.tracer.info("{0}.{1}() method called with isForce={2}".format(self.__class__.__name__, method, isForce))
             if not isForce:
                 # run pre takeover code
@@ -90,7 +90,7 @@ try:
                 return 0
 
         def postTakeover(self, rc, **kwargs):
-            method="postTakeover"
+            method = "postTakeover"
             """Post takeover hook."""
             self.tracer.info("{0}.{1}() method called with rc={2}".format(self.__class__.__name__, method, rc))
             if rc == 0:
@@ -104,9 +104,9 @@ try:
                 return 0
 
         def srConnectionChanged(self, ParamDict, **kwargs):
-            method="srConnectionChanged"
+            method = "srConnectionChanged"
             """ finally we got the srConnection hook :) """
-            self.tracer.info("{0}.{1}() method called with Dict={2} (version {3})".format(self.__class__.__name__, method, ParamDict,fhSRHookVersion))
+            self.tracer.info("{0}.{1}() method called with Dict={2} (version {3})".format(self.__class__.__name__, method, ParamDict, fhSRHookVersion))
             # myHostname = socket.gethostname()
             # myDatebase = ParamDict["database"]
             mySystemStatus = ParamDict["system_status"]
@@ -115,18 +115,18 @@ try:
             myInSync = ParamDict["is_in_sync"]
             myReason = ParamDict["reason"]
             mySite = ParamDict["siteName"]
-            if (mySystemStatus == 15):
+            if mySystemStatus == 15:
                 mySRS = "SOK"
             else:
-                if (myInSync):
+                if myInSync:
                     # ignoring the SFAIL, because we are still in sync
                     self.tracer.info("{0}.{1}() ignoring bad SR status because of is_in_sync=True (reason={2})".format(self.__class__.__name__, method, myReason))
                     mySRS = ""
                 else:
                     mySRS = "SFAIL"
-            if ( mySRS == "" ):
+            if  mySRS == "" :
                 myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
-            elif ( mySite == "" ):
+            elif mySite == "" :
                 myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
                 self.tracer.info("{0}.{1}() was called with empty site name. Ignoring call.".format(self.__class__.__name__, method))
             else:

--- a/SAPHana/srHook/SAPHanaSrMultiTarget.py
+++ b/SAPHana/srHook/SAPHanaSrMultiTarget.py
@@ -5,11 +5,11 @@
 # Copyright:    (c) 2015-2016 SUSE Linux GmbH
 # Copyright:    (c) 2017-2020 SUSE LLC
 
-SAPHanaSR needs SAP HANA 2.0 SPS4 (2.00.040.00) as minimum version
+SAPHanaSrMt needs SAP HANA 2.0 SPS4 (2.00.040.00) as minimum version
 """
 import os, time
 
-fhSRHookVersion = "0.170.3.0716.1509"
+fhSRHookVersion = "0.170.3.0716.1640"
 
 try:
     from hdb_ha_dr.client import HADRBase
@@ -20,8 +20,8 @@ except ImportError as e:
 Only for SAP HANA >= 2.0 SPS3
 
 To use this HA/DR hook provide please add the following lines (or similar) to your global.ini:
-    [ha_dr_provider_SAPHanaSR]
-    provider = SAPHanaSR
+    [ha_dr_provider_SAPHanaSrMt]
+    provider = SAPHanaSrMt
     path = /usr/share/SAPHanaSR-ScaleOut
     execution_order = 1
 
@@ -30,11 +30,11 @@ To use this HA/DR hook provide please add the following lines (or similar) to yo
 """
 
 try:
-    class SAPHanaSR(HADRBase):
+    class SAPHanaSrMt(HADRBase):
 
         def __init__(self, *args, **kwargs):
             # delegate construction to base class
-            super(SAPHanaSR, self).__init__(*args, **kwargs)
+            super(SAPHanaSrMt, self).__init__(*args, **kwargs)
             method = "init"
             self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__, method, fhSRHookVersion))
 
@@ -42,7 +42,7 @@ try:
             method = "about"
             self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__, method, fhSRHookVersion))
             return {"provider_company": "SUSE",
-                    "provider_name": "SAPHanaSR",  # class name
+                    "provider_name": "SAPHanaSrMt",  # class name
                     "provider_description": "Inform Cluster about SR state",
                     "provider_version": "1.0"}
 
@@ -124,16 +124,17 @@ try:
                     mySRS = ""
                 else:
                     mySRS = "SFAIL"
-            if  mySRS == "" :
+            if mySRS == "":
                 myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
-            elif mySite == "" :
+                self.tracer.info("{0}.{1}() {2}\n".format( self.__class__.__name__, method, myMSG ))
+            elif mySite == "":
                 myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
                 self.tracer.info("{0}.{1}() was called with empty site name. Ignoring call.".format(self.__class__.__name__, method))
             else:
                 myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_site_srHook_{1} -v {2} -t crm_config -s SAPHanaSR".format(mysid, mySite, mySRS)
                 rc = os.system(myCMD)
-                myMSG = "CALLING CRM: <" + myCMD + "> rc=" + str(rc)
-            self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
+                myMSG = "CALLING CRM: <{0}> rc={1}".format( myCMD, rc )
+                self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
             return 0
 except NameError as e:
         print("Could not find base class ({0})".format(e))

--- a/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
+++ b/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
@@ -1,108 +1,116 @@
-from hdb_ha_dr.client import HADRBase
+
 import os, time
 
-fhSRHookVersion = "0.170.3.0706.1112"
+fhSRHookVersion = "0.170.3.0706.1316"
 
+try:
+    from hdb_ha_dr.client import HADRBase
+except ImportError as e:
+    print("Module HADRBase not found - running outside if SAP HANA? - {0}".format(e))
 
-class SAPHanaSrTakeoverBlocker(HADRBase):
+try:
+    class SAPHanaSrTakeoverBlocker(HADRBase):
 
-    def __init__(self, *args, **kwargs):
-        # delegate construction to base class
-        super(SAPHanaSrTakeoverBlocker, self).__init__(*args, **kwargs)
+        def __init__(self, *args, **kwargs):
+            self.tracer.info("Initialize {0} {1}".format(self.__class__.__name__,fhSRHookVersion))
+            # delegate construction to base class
+            super(SAPHanaSrTakeoverBlocker, self).__init__(*args, **kwargs)
 
-    def about(self):
-        return {"provider_company": "SUSE",
-                "provider_name": "SAPHanaSrTakeoverBlocker",  # class name
-                "provider_description": "Inform Cluster about SR state",
-                "provider_version": "1.0"}
+        def about(self):
+            return {"provider_company": "SUSE",
+                    "provider_name": "SAPHanaSrTakeoverBlocker",  # class name
+                    "provider_description": "Inform Cluster about SR state",
+                    "provider_version": "1.0"}
 
-    def startup(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter startup hook; {0}".format(locals()))
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave startup hook")
-        return 0
+        def startup(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter startup hook; {0}".format(locals()))
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave startup hook")
+            return 0
 
-    def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter shutdown hook; {0}".format(locals()))
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave shutdown hook")
-        return 0
+        def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter shutdown hook; {0}".format(locals()))
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave shutdown hook")
+            return 0
 
-    def failover(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter failover hook; {0}".format(locals()))
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave failover hook")
-        return 0
+        def failover(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter failover hook; {0}".format(locals()))
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave failover hook")
+            return 0
 
-    def stonith(self, failingHost, **kwargs):
-        self.tracer.debug("enter stonith hook; {0}".format(locals()))
-        self.tracer.debug(self.config.toString())
-        # e.g. stonith of params["failed_host"]
-        # e-g- set vIP active
-        self.tracer.info("leave stonith hook")
-        return 0
+        def stonith(self, failingHost, **kwargs):
+            self.tracer.debug("enter stonith hook; {0}".format(locals()))
+            self.tracer.debug(self.config.toString())
+            # e.g. stonith of params["failed_host"]
+            # e-g- set vIP active
+            self.tracer.info("leave stonith hook")
+            return 0
 
-    def preTakeover(self, isForce, **kwargs):
-        """Pre takeover hook."""
-        """
-           * TODO PRIO1: add check, if cluster does actively manage the resource
-           * Prerequisites:
-           *    RA does set the same attribute as checked here (key and value)
-           *    Sudoers does allow the query of the attribute (alternatively add <sid>adm user(s) to hacluster group)
-        """
-        self.tracer.info("{0}.preTakeover method called with isForce={1}".format(self.__class__.__name__, isForce))
-        if not isForce:
-            # run pre takeover code
-            # run pre-check, return != 0 in case of error => will abort takeover
-            # for test purposes just block all sr_takeover() calls
-            mySID = os.environ.get('SAPSYSTEMNAME')
-            mysid = mySID.lower()
-            myAttribute = "hana_{0}_sra".format( mysid )
-            myCMD = "sudo /usr/sbin/crm_attribute -n {0} -G -t reboot -q".format( myAttribute )
-            self.tracer.info("{0}.preTakeover myCMD is: {1}".format(self.__class__.__name__, myCMD))
-            mySRA = ""
-            mySRAres = os.popen(myCMD)
+        def preTakeover(self, isForce, **kwargs):
+            """Pre takeover hook."""
             """
-            Discussion about getting return code of object.popen() calls with either object.poll() or object.wait()
-               https://stackoverflow.com/questions/36596354/how-to-get-exit-code-from-subprocess-popen
-               # Wait until process terminates (without using p.wait())
-               while p.poll() is None:
-                   # Process hasn't exited yet, let's wait some
-                   time.sleep(0.5)
-               However they are using subprocess (maybe also python3) instead
+               * TODO PRIO1: add check, if cluster does actively manage the resource
+               * Prerequisites:
+               *    RA does set the same attribute as checked here (key and value)
+               *    Sudoers does allow the query of the attribute (alternatively add <sid>adm user(s) to hacluster group)
             """
-            mySRAlines = list(mySRAres)
-            for line in mySRAlines:
-                mySRA = mySRA + line
-            mySRA = mySRA.rstrip()
-            if ( mySRA == "T" ):
-               self.tracer.info("{0}.preTakeover permit cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
-               rc = 0
+            self.tracer.info("{0}.preTakeover method called with isForce={1}".format(self.__class__.__name__, isForce))
+            if not isForce:
+                # run pre takeover code
+                # run pre-check, return != 0 in case of error => will abort takeover
+                # for test purposes just block all sr_takeover() calls
+                mySID = os.environ.get('SAPSYSTEMNAME')
+                mysid = mySID.lower()
+                myAttribute = "hana_{0}_sra".format( mysid )
+                myCMD = "sudo /usr/sbin/crm_attribute -n {0} -G -t reboot -q".format( myAttribute )
+                self.tracer.info("{0}.preTakeover myCMD is: {1}".format(self.__class__.__name__, myCMD))
+                mySRA = ""
+                mySRAres = os.popen(myCMD)
+                """
+                Discussion about getting return code of object.popen() calls with either object.poll() or object.wait()
+                   https://stackoverflow.com/questions/36596354/how-to-get-exit-code-from-subprocess-popen
+                   # Wait until process terminates (without using p.wait())
+                   while p.poll() is None:
+                       # Process hasn't exited yet, let's wait some
+                       time.sleep(0.5)
+                   However they are using subprocess (maybe also python3) instead
+                """
+                mySRAlines = list(mySRAres)
+                for line in mySRAlines:
+                    mySRA = mySRA + line
+                mySRA = mySRA.rstrip()
+                if ( mySRA == "T" ):
+                   self.tracer.info("{0}.preTakeover permit cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
+                   rc = 0
+                else:
+                   self.tracer.info("{0}.preTakeover reject non-cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
+                   try:
+                       rc = self.errorCodeClusterConfigured # take the correct rc from HANA settings
+                   except:
+                       rc = 50277  # fallback for self.errorCodeClusterConfigured, if HANA does not already provide the rc codes
+                return rc
             else:
-               self.tracer.info("{0}.preTakeover reject non-cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
-               try:
-                   rc = self.errorCodeClusterConfigured # take the correct rc from HANA settings
-               except:
-                   rc = 50277  # fallback for self.errorCodeClusterConfigured, if HANA does not already provide the rc codes
-            return rc
-        else:
-            # possible force-takeover only code
-            # usually nothing to do here
-            return 0
+                # possible force-takeover only code
+                # usually nothing to do here
+                return 0
 
-    def postTakeover(self, rc, **kwargs):
-        """Post takeover hook."""
-        self.tracer.info("{0}.postTakeover method called with rc={1}".format(self.__class__.__name__, rc))
-        if rc == 0:
-            # normal takeover succeeded
-            return 0
-        elif rc == 1:
-            # waiting for force takeover
-            return 0
-        elif rc == 2:
-            # error, something went wrong
-            return 0
+        def postTakeover(self, rc, **kwargs):
+            """Post takeover hook."""
+            self.tracer.info("{0}.postTakeover method called with rc={1}".format(self.__class__.__name__, rc))
+            if rc == 0:
+                # normal takeover succeeded
+                return 0
+            elif rc == 1:
+                # waiting for force takeover
+                return 0
+            elif rc == 2:
+                # error, something went wrong
+                return 0
 
-    def srConnectionChanged(self, ParamDict, **kwargs):
-        """ This hook should just do nothing for this HA/DR method """
-        return 0
+        def srConnectionChanged(self, ParamDict, **kwargs):
+            """ This hook should just do nothing for this HA/DR method """
+            return 0
+except NameError as e:
+        print("Could not find base class ({0})".format(e))

--- a/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
+++ b/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
@@ -62,6 +62,15 @@ class SAPHanaSrTakeoverBlocker(HADRBase):
             self.tracer.info("%s.preTakeover myCMD is: %s" % (self.__class__.__name__, myCMD))
             mySRA = ""
             mySRAres = os.popen(myCMD)
+            """
+            Discussion about getting return code of object.popen() calls with either object.poll() or object.wait()
+               https://stackoverflow.com/questions/36596354/how-to-get-exit-code-from-subprocess-popen
+               # Wait until process terminates (without using p.wait())
+               while p.poll() is None:
+                   # Process hasn't exited yet, let's wait some
+                   time.sleep(0.5)
+               However they are using subprocess (maybe also python3) instead    
+            """
             mySRAlines = list(mySRAres)
             for line in mySRAlines:
                 mySRA = mySRA + line

--- a/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
+++ b/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
@@ -17,25 +17,25 @@ class SAPHanaSrTakeoverBlocker(HADRBase):
                 "provider_version": "1.0"}
 
     def startup(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter startup hook; %s" % locals())
+        self.tracer.debug("enter startup hook; {0}".format(locals()))
         self.tracer.debug(self.config.toString())
         self.tracer.info("leave startup hook")
         return 0
 
     def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter shutdown hook; %s" % locals())
+        self.tracer.debug("enter shutdown hook; {0}".format(locals()))
         self.tracer.debug(self.config.toString())
         self.tracer.info("leave shutdown hook")
         return 0
 
     def failover(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter failover hook; %s" % locals())
+        self.tracer.debug("enter failover hook; {0}".format(locals()))
         self.tracer.debug(self.config.toString())
         self.tracer.info("leave failover hook")
         return 0
 
     def stonith(self, failingHost, **kwargs):
-        self.tracer.debug("enter stonith hook; %s" % locals())
+        self.tracer.debug("enter stonith hook; {0}".format(locals()))
         self.tracer.debug(self.config.toString())
         # e.g. stonith of params["failed_host"]
         # e-g- set vIP active
@@ -50,27 +50,36 @@ class SAPHanaSrTakeoverBlocker(HADRBase):
            *    RA does set the same attribute as checked here (key and value)
            *    Sudoers does allow the query of the attribute (alternatively add <sid>adm user(s) to hacluster group)
         """
-        self.tracer.info("%s.preTakeover method called with isForce=%s" % (self.__class__.__name__, isForce))
+        self.tracer.info("{0}.preTakeover method called with isForce={1}".format(self.__class__.__name__, isForce))
         if not isForce:
             # run pre takeover code
             # run pre-check, return != 0 in case of error => will abort takeover
             # for test purposes just block all sr_takeover() calls
             mySID = os.environ.get('SAPSYSTEMNAME')
             mysid = mySID.lower()
-            myAttribute = "hana_" + mysid + "_sra"
-            myCMD = "sudo /usr/sbin/crm_attribute -n hana_" + mysid + "_sra -G -t reboot -q"
-            self.tracer.info("%s.preTakeover myCMD is: %s" % (self.__class__.__name__, myCMD))
+            myAttribute = "hana_{0}_sra".format( mysid )
+            myCMD = "sudo /usr/sbin/crm_attribute -n {0} -G -t reboot -q".format( myAttribute )
+            self.tracer.info("{0}.preTakeover myCMD is: {1}".format(self.__class__.__name__, myCMD))
             mySRA = ""
             mySRAres = os.popen(myCMD)
+            """
+            Discussion about getting return code of object.popen() calls with either object.poll() or object.wait()
+               https://stackoverflow.com/questions/36596354/how-to-get-exit-code-from-subprocess-popen
+               # Wait until process terminates (without using p.wait())
+               while p.poll() is None:
+                   # Process hasn't exited yet, let's wait some
+                   time.sleep(0.5)
+               However they are using subprocess (maybe also python3) instead
+            """
             mySRAlines = list(mySRAres)
             for line in mySRAlines:
                 mySRA = mySRA + line
             mySRA = mySRA.rstrip()
             if ( mySRA == "T" ):
-               self.tracer.info("%s.preTakeover permit cluster action sr_takeover() sra=%s" % (self.__class__.__name__, mySRA))
+               self.tracer.info("{0}.preTakeover permit cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
                rc = 0
             else:
-               self.tracer.info("%s.preTakeover reject non-cluster action sr_takeover() sra=%s" % (self.__class__.__name__, mySRA))
+               self.tracer.info("{0}.preTakeover reject non-cluster action sr_takeover() sra={1}".format(self.__class__.__name__, mySRA))
                try:
                    rc = self.errorCodeClusterConfigured # take the correct rc from HANA settings
                except:
@@ -83,7 +92,7 @@ class SAPHanaSrTakeoverBlocker(HADRBase):
 
     def postTakeover(self, rc, **kwargs):
         """Post takeover hook."""
-        self.tracer.info("%s.postTakeover method called with rc=%s" % (self.__class__.__name__, rc))
+        self.tracer.info("{0}.postTakeover method called with rc={1}".format(self.__class__.__name__, rc))
         if rc == 0:
             # normal takeover succeeded
             return 0

--- a/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
+++ b/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
@@ -11,10 +11,10 @@ except ImportError as e:
 try:
     class SAPHanaSrTakeoverBlocker(HADRBase):
 
-        def __init__(self, *args, **kwargs):
-            self.tracer.info("Initialize {0} {1}".format(self.__class__.__name__,fhSRHookVersion))
+        def __init__(self, *args, **kwargs):            
             # delegate construction to base class
             super(SAPHanaSrTakeoverBlocker, self).__init__(*args, **kwargs)
+            self.tracer.info("Initialize {0} {1}".format(self.__class__.__name__,fhSRHookVersion))
 
         def about(self):
             return {"provider_company": "SUSE",

--- a/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
+++ b/SAPHana/srHook/SAPHanaSrTakeoverBlocker.py
@@ -1,7 +1,7 @@
 from hdb_ha_dr.client import HADRBase
 import os, time
 
-fhSRHookVersion = "0.162.0"
+fhSRHookVersion = "0.170.3.0706.1112"
 
 
 class SAPHanaSrTakeoverBlocker(HADRBase):
@@ -71,7 +71,10 @@ class SAPHanaSrTakeoverBlocker(HADRBase):
                rc = 0
             else:
                self.tracer.info("%s.preTakeover reject non-cluster action sr_takeover() sra=%s" % (self.__class__.__name__, mySRA))
-               rc = 1
+               try:
+                   rc = self.errorCodeClusterConfigured # take the correct rc from HANA settings
+               except:
+                   rc = 50277  # fallback for self.errorCodeClusterConfigured, if HANA does not already provide the rc codes
             return rc
         else:
             # possible force-takeover only code

--- a/SAPHana/srHook/saphana-sr-multi-target.py
+++ b/SAPHana/srHook/saphana-sr-multi-target.py
@@ -35,33 +35,41 @@ try:
         def __init__(self, *args, **kwargs):
             # delegate construction to base class
             super(SAPHanaSR, self).__init__(*args, **kwargs)
+            method="init"
+            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__,method,fhSRHookVersion))
 
         def about(self):
+            method="about"
+            self.tracer.info("{0}.{1}() version {2}".format(self.__class__.__name__,method,fhSRHookVersion))
             return {"provider_company": "SUSE",
                     "provider_name": "SAPHanaSR",  # class name
                     "provider_description": "Inform Cluster about SR state",
                     "provider_version": "1.0"}
 
         def startup(self, hostname, storage_partition, sr_mode, **kwargs):
-            self.tracer.debug("enter startup hook; %s" % locals())
+            method="startup"
+            self.tracer.debug("enter startup hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave startup hook")
             return 0
 
         def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
-            self.tracer.debug("enter shutdown hook; %s" % locals())
+            method="shutdown"
+            self.tracer.debug("enter shutdown hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave shutdown hook")
             return 0
 
         def failover(self, hostname, storage_partition, sr_mode, **kwargs):
-            self.tracer.debug("enter failover hook; %s" % locals())
+            method="failover"
+            self.tracer.debug("enter failover hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             self.tracer.info("leave failover hook")
             return 0
 
         def stonith(self, failingHost, **kwargs):
-            self.tracer.debug("enter stonith hook; %s" % locals())
+            method="stonith"
+            self.tracer.debug("enter stonith hook; {0}".format(locals()))
             self.tracer.debug(self.config.toString())
             # e.g. stonith of params["failed_host"]
             # e-g- set vIP active
@@ -70,7 +78,8 @@ try:
 
         def preTakeover(self, isForce, **kwargs):
             """Pre takeover hook."""
-            self.tracer.info("%s.preTakeover method called with isForce=%s" % (self.__class__.__name__, isForce))
+            method="preTakeover"
+            self.tracer.info("{0}.{1}() method called with isForce={2}".format(self.__class__.__name__, method, isForce))
             if not isForce:
                 # run pre takeover code
                 # run pre-check, return != 0 in case of error => will abort takeover
@@ -81,8 +90,9 @@ try:
                 return 0
 
         def postTakeover(self, rc, **kwargs):
+            method="postTakeover"
             """Post takeover hook."""
-            self.tracer.info("%s.postTakeover method called with rc=%s" % (self.__class__.__name__, rc))
+            self.tracer.info("{0}.{1}() method called with rc={2}".format(self.__class__.__name__, method, rc))
             if rc == 0:
                 # normal takeover succeeded
                 return 0
@@ -94,8 +104,9 @@ try:
                 return 0
 
         def srConnectionChanged(self, ParamDict, **kwargs):
+            method="srConnectionChanged"
             """ finally we got the srConnection hook :) """
-            self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged method called with Dict=%s" % (fhSRHookVersion, self.__class__.__name__, ParamDict))
+            self.tracer.info("{0}.{1}() method called with Dict={2} (version {3})".format(self.__class__.__name__, method, ParamDict,fhSRHookVersion))
             # myHostname = socket.gethostname()
             # myDatebase = ParamDict["database"]
             mySystemStatus = ParamDict["system_status"]
@@ -109,23 +120,20 @@ try:
             else:
                 if (myInSync):
                     # ignoring the SFAIL, because we are still in sync
-                    self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged ignoring bad SR status because of is_in_sync=True (reason=%s)" % (fhSRHookVersion, self.__class__.__name__, myReason))
+                    self.tracer.info("{0}.{1}() ignoring bad SR status because of is_in_sync=True (reason={2})".format(self.__class__.__name__, method, myReason))
                     mySRS = ""
                 else:
                     mySRS = "SFAIL"
             if ( mySRS == "" ):
-                self.tracer.info("SAPHanaSR (%s) 001" % (self.__class__.__name__))
                 myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
-                self.tracer.info("SAPHanaSR (%s) 002" % (self.__class__.__name__))
             elif ( mySite == "" ):
                 myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
-                self.tracer.info("SAPHanaSR (%s) was called with empty site name. Ignoring call." % (self.__class__.__name__))
+                self.tracer.info("{0}.{1}() was called with empty site name. Ignoring call.".format(self.__class__.__name__, method))
             else:
-                myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
+                myCMD = "sudo /usr/sbin/crm_attribute -n hana_{0}_site_srHook_{1} -v {2} -t crm_config -s SAPHanaSR".format(mysid, mySite, mySRS)
                 rc = os.system(myCMD)
                 myMSG = "CALLING CRM: <" + myCMD + "> rc=" + str(rc)
-            self.tracer.info("SAPHanaSR %s.srConnectionChanged method called with Dict=%s ###\n" % (self.__class__.__name__, ParamDict))
-            self.tracer.info("SAPHanaSR %s \n" % (myMSG))
+            self.tracer.info("{0}.{1}() {2}\n".format(self.__class__.__name__, method, myMSG))
             return 0
 except NameError as e:
         print("Could not find base class ({0})".format(e))

--- a/SAPHana/srHook/saphana-sr-multi-target.py
+++ b/SAPHana/srHook/saphana-sr-multi-target.py
@@ -7,9 +7,14 @@
 
 SAPHanaSR needs SAP HANA 2.0 SPS4 (2.00.040.00) as minimum version
 """
+import os, time
 
-from hdb_ha_dr.client import HADRBase
-import os
+fhSRHookVersion = "0.170.3.0706.1711"
+
+try:
+    from hdb_ha_dr.client import HADRBase
+except ImportError as e:
+    print("Module HADRBase not found - running outside of SAP HANA? - {0}".format(e))
 
 """
 Only for SAP HANA >= 2.0 SPS3
@@ -23,103 +28,104 @@ To use this HA/DR hook provide please add the following lines (or similar) to yo
     [trace]
     ha_dr_saphanasr = info
 """
-fhSRHookVersion = "0.170.3.0706.1648"
 
+try:
+    class SAPHanaSR(HADRBase):
 
-class SAPHanaSR(HADRBase):
+        def __init__(self, *args, **kwargs):
+            # delegate construction to base class
+            super(SAPHanaSR, self).__init__(*args, **kwargs)
 
-    def __init__(self, *args, **kwargs):
-        # delegate construction to base class
-        super(SAPHanaSR, self).__init__(*args, **kwargs)
+        def about(self):
+            return {"provider_company": "SUSE",
+                    "provider_name": "SAPHanaSR",  # class name
+                    "provider_description": "Inform Cluster about SR state",
+                    "provider_version": "1.0"}
 
-    def about(self):
-        return {"provider_company": "SUSE",
-                "provider_name": "SAPHanaSR",  # class name
-                "provider_description": "Inform Cluster about SR state",
-                "provider_version": "1.0"}
-
-    def startup(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter startup hook; %s" % locals())
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave startup hook")
-        return 0
-
-    def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter shutdown hook; %s" % locals())
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave shutdown hook")
-        return 0
-
-    def failover(self, hostname, storage_partition, sr_mode, **kwargs):
-        self.tracer.debug("enter failover hook; %s" % locals())
-        self.tracer.debug(self.config.toString())
-        self.tracer.info("leave failover hook")
-        return 0
-
-    def stonith(self, failingHost, **kwargs):
-        self.tracer.debug("enter stonith hook; %s" % locals())
-        self.tracer.debug(self.config.toString())
-        # e.g. stonith of params["failed_host"]
-        # e-g- set vIP active
-        self.tracer.info("leave stonith hook")
-        return 0
-
-    def preTakeover(self, isForce, **kwargs):
-        """Pre takeover hook."""
-        self.tracer.info("%s.preTakeover method called with isForce=%s" % (self.__class__.__name__, isForce))
-        if not isForce:
-            # run pre takeover code
-            # run pre-check, return != 0 in case of error => will abort takeover
-            return 0
-        else:
-            # possible force-takeover only code
-            # usually nothing to do here
+        def startup(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter startup hook; %s" % locals())
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave startup hook")
             return 0
 
-    def postTakeover(self, rc, **kwargs):
-        """Post takeover hook."""
-        self.tracer.info("%s.postTakeover method called with rc=%s" % (self.__class__.__name__, rc))
-        if rc == 0:
-            # normal takeover succeeded
-            return 0
-        elif rc == 1:
-            # waiting for force takeover
-            return 0
-        elif rc == 2:
-            # error, something went wrong
+        def shutdown(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter shutdown hook; %s" % locals())
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave shutdown hook")
             return 0
 
-    def srConnectionChanged(self, ParamDict, **kwargs):
-        """ finally we got the srConnection hook :) """
-        self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged method called with Dict=%s" % (fhSRHookVersion, self.__class__.__name__, ParamDict))
-        # myHostname = socket.gethostname()
-        # myDatebase = ParamDict["database"]
-        mySystemStatus = ParamDict["system_status"]
-        mySID = os.environ.get('SAPSYSTEMNAME')
-        mysid = mySID.lower()
-        myInSync = ParamDict["is_in_sync"]
-        myReason = ParamDict["reason"]
-        mySite = ParamDict["siteName"]
-        if (mySystemStatus == 15):
-            mySRS = "SOK"
-        else:
-            if (myInSync):
-                # ignoring the SFAIL, because we are still in sync
-                self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged ignoring bad SR status because of is_in_sync=True (reason=%s)" % (fhSRHookVersion, self.__class__.__name__, myReason))
-                mySRS = ""
+        def failover(self, hostname, storage_partition, sr_mode, **kwargs):
+            self.tracer.debug("enter failover hook; %s" % locals())
+            self.tracer.debug(self.config.toString())
+            self.tracer.info("leave failover hook")
+            return 0
+
+        def stonith(self, failingHost, **kwargs):
+            self.tracer.debug("enter stonith hook; %s" % locals())
+            self.tracer.debug(self.config.toString())
+            # e.g. stonith of params["failed_host"]
+            # e-g- set vIP active
+            self.tracer.info("leave stonith hook")
+            return 0
+
+        def preTakeover(self, isForce, **kwargs):
+            """Pre takeover hook."""
+            self.tracer.info("%s.preTakeover method called with isForce=%s" % (self.__class__.__name__, isForce))
+            if not isForce:
+                # run pre takeover code
+                # run pre-check, return != 0 in case of error => will abort takeover
+                return 0
             else:
-                mySRS = "SFAIL"
-        if ( mySRS == "" ):
-            self.tracer.info("SAPHanaSR (%s) 001" % (self.__class__.__name__))
-            myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
-            self.tracer.info("SAPHanaSR (%s) 002" % (self.__class__.__name__))
-        elif ( mySite == "" ):
-            myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
-            self.tracer.info("SAPHanaSR (%s) was called with empty site name. Ignoring call." % (self.__class__.__name__))
-        else:
-            myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
-            rc = os.system(myCMD)
-            myMSG = "CALLING CRM: <" + myCMD + "> rc=" + str(rc)
-        self.tracer.info("SAPHanaSR %s.srConnectionChanged method called with Dict=%s ###\n" % (self.__class__.__name__, ParamDict))
-        self.tracer.info("SAPHanaSR %s \n" % (myMSG))
-        return 0
+                # possible force-takeover only code
+                # usually nothing to do here
+                return 0
+
+        def postTakeover(self, rc, **kwargs):
+            """Post takeover hook."""
+            self.tracer.info("%s.postTakeover method called with rc=%s" % (self.__class__.__name__, rc))
+            if rc == 0:
+                # normal takeover succeeded
+                return 0
+            elif rc == 1:
+                # waiting for force takeover
+                return 0
+            elif rc == 2:
+                # error, something went wrong
+                return 0
+
+        def srConnectionChanged(self, ParamDict, **kwargs):
+            """ finally we got the srConnection hook :) """
+            self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged method called with Dict=%s" % (fhSRHookVersion, self.__class__.__name__, ParamDict))
+            # myHostname = socket.gethostname()
+            # myDatebase = ParamDict["database"]
+            mySystemStatus = ParamDict["system_status"]
+            mySID = os.environ.get('SAPSYSTEMNAME')
+            mysid = mySID.lower()
+            myInSync = ParamDict["is_in_sync"]
+            myReason = ParamDict["reason"]
+            mySite = ParamDict["siteName"]
+            if (mySystemStatus == 15):
+                mySRS = "SOK"
+            else:
+                if (myInSync):
+                    # ignoring the SFAIL, because we are still in sync
+                    self.tracer.info("SAPHanaSR (%s) %s.srConnectionChanged ignoring bad SR status because of is_in_sync=True (reason=%s)" % (fhSRHookVersion, self.__class__.__name__, myReason))
+                    mySRS = ""
+                else:
+                    mySRS = "SFAIL"
+            if ( mySRS == "" ):
+                self.tracer.info("SAPHanaSR (%s) 001" % (self.__class__.__name__))
+                myMSG = "### Ignoring bad SR status because of is_in_sync=True ###"
+                self.tracer.info("SAPHanaSR (%s) 002" % (self.__class__.__name__))
+            elif ( mySite == "" ):
+                myMSG = "### Ignoring bad SR status because of empty site name in call params ###"
+                self.tracer.info("SAPHanaSR (%s) was called with empty site name. Ignoring call." % (self.__class__.__name__))
+            else:
+                myCMD = "sudo /usr/sbin/crm_attribute -n hana_%s_site_srHook_%s -v %s -t crm_config -s SAPHanaSR" % (mysid, mySite, mySRS)
+                rc = os.system(myCMD)
+                myMSG = "CALLING CRM: <" + myCMD + "> rc=" + str(rc)
+            self.tracer.info("SAPHanaSR %s.srConnectionChanged method called with Dict=%s ###\n" % (self.__class__.__name__, ParamDict))
+            self.tracer.info("SAPHanaSR %s \n" % (myMSG))
+            return 0
+except NameError as e:
+        print("Could not find base class ({0})".format(e))

--- a/SAPHana/srHook/saphana-sr-multi-target.py
+++ b/SAPHana/srHook/saphana-sr-multi-target.py
@@ -1,23 +1,29 @@
+"""
+# SAPHana
+# Author:       Fabian Herschel, 2015
+# License:      GNU General Public License (GPL)
+# Copyright:    (c) 2015-2016 SUSE Linux GmbH
+# Copyright:    (c) 2017-2020 SUSE LLC
+
+SAPHanaSR needs SAP HANA 2.0 SPS4 (2.00.040.00) as minimum version
+"""
+
 from hdb_ha_dr.client import HADRBase
 import os
 
 """
 Only for SAP HANA >= 2.0 SPS3
 
-Sample for a HA/DR hook provider.
-When using your own code in here, please copy this file to location on
-/hana/shared outside the HANA installation.
-To use this HA/DR hook provide please add the following lines (or
-similar) to your global.ini:
+To use this HA/DR hook provide please add the following lines (or similar) to your global.ini:
     [ha_dr_provider_SAPHanaSR]
     provider = SAPHanaSR
-    path = /hana/shared/myHooks/SAPHanaSR-ScaleOut
+    path = /usr/share/SAPHanaSR-ScaleOut
     execution_order = 1
 
     [trace]
     ha_dr_saphanasr = info
 """
-fhSRHookVersion = "0.162.0.0629.1538"
+fhSRHookVersion = "0.170.3.0706.1648"
 
 
 class SAPHanaSR(HADRBase):

--- a/SAPHana/test/SAPHanaSR-filter
+++ b/SAPHana/test/SAPHanaSR-filter
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+#  <relpath>="<value>"
+use strict;
+use Getopt::Long;
+
+my @search;
+my $cibTime;
+my $key; my $value;
+my %lastVal;
+my $previous;
+my $p;
+my $filterDouble=0;
+my $showFormerValues=0;
+my $formerString="";
+my $version=0;
+my $help=0;
+my $theVersion="0.1.2019.08.30.1";
+
+sub init()
+{
+    my $result = GetOptions ("search=s" => \@search,
+                          "filterDouble" => \$filterDouble,
+                          "showFormerValues" => \$showFormerValues,
+                          "version" => \$version,
+                          "help" => \$help,
+         );
+   return 0;
+}
+
+init();
+
+#  
+while ( <> ) {
+    if ( /(.*)="(.*)"/ ) {
+        # lines like: a/b/c="d e f"
+        $key="$1"; $value="$2";
+        if ( $key eq "Global/global/cib-time" ) {
+            $cibTime=$value;
+        } else {
+            foreach my $search ( @search ) {
+                if ( $key =~ $search ) {
+                    if ( defined $lastVal{$key} ) {
+                        $previous=$lastVal{$key};
+                        if ( $previous eq $value ) {
+                            $p=1;
+                        } else {
+                            # new value, store and mark line to be printed
+                            $lastVal{$key}=$value;
+                            $p=0;
+                        }
+                    } else {
+                            # new value and empty hash slot, store and mark line to be printed
+                            $previous="";
+                            $lastVal{$key}=$value;
+                            $p=0;
+                    }
+                    if ( $showFormerValues  && $previous ) {
+                       $formerString=sprintf("; (%s)", $previous);
+                    } else {
+                       $formerString = "";
+                    }
+                    if ( (! $filterDouble ) || ( $p == 0 )) {
+                        printf "%s; %s=%s%s\n", $cibTime, $key, $value, $formerString;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SAPHana/test/SAPHanaSR-replay-archive
+++ b/SAPHana/test/SAPHanaSR-replay-archive
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+##########################################################################
+#
+# SAPHanaSR-replay
+#
+# Author:       Fabian Herschel, November 2015
+# Support:      linux@sap.com
+# License:      GNU General Public License 2 (GPLv2)
+# Copyright (c) 2014-2016 SUSE Linux GmbH, Nuernberg, Germany.
+# Copyright (c) 2017-2019 SUSE LLC.
+#
+##########################################################################
+#
+# Syntax:
+# SAPHanaSR-replay-archive <path-to-pengine-archive> (tar.bz2)
+#
+# SAPHanaSR-replay-archive archive-containing-some-pengine-directories
+#
+##########################################################################
+#
+####################
+#
+version="1.0";
+# some help to the newbie
+exe="$0"
+bex=$(basename "$exe")
+format="tables";
+outDir="";
+pengine="";
+#
+while [ $# -gt 0 ]; do
+    case "$1" in
+     --help|-h)
+        echo
+        echo "usage:    $bex [--format=script] /path/to/pe-archive (tar.bz2)"
+        echo
+        echo "usage:    $bex [OPTION]"
+        echo " --help		show help."
+        echo " --version	show version."
+        echo
+        exit
+    ;;
+     --version|-v)
+        echo "$bex version $version"
+        exit
+    ;;
+        --format=* )
+            format=${1#*=}
+    ;;
+        --outDir=* )
+            outDir=${1#*=}
+    ;;
+        --pengine=* )
+            pengine=${1#*=}
+	    echo "pengine directory $pengine"
+    ;;
+        * )
+        archive="$1"
+    ;;
+    esac
+    shift
+done
+
+#
+####################
+#
+#
+if [ -z "$pengine" ]; then
+	echo "pengine is not set"
+    mkdir -p "${archive}-tmp"
+    if ! tar -xjf "$archive" -C "${archive}-tmp" ; then echo "Extracting archive $archive failed"; exit 2; fi
+    if ! cd "${archive}-tmp"; then echo "Can not enter archive directory ${archive}-tmp"; exit 2; fi
+else
+	echo "pengine is set"
+        cd $pengine; cd ..
+fi
+#
+####################
+#
+# find pengine directories
+#
+pDirs=$(find . -type d -name pengine)
+
+#
+####################
+#
+# find all pengine inputs sorted by time
+#
+pFiles=$(find $pDirs -name '*input*')
+pFilesSorted=$(ls -tr $pFiles)
+
+#
+####################
+#
+# find all cib.txt files
+#
+cFiles=$(find . -type f -name cib.txt)
+
+#
+####################
+#
+# find all SIDs mentioned in the cib.txt
+#
+sids=$(
+for cF in $cFiles; do
+    while read line
+    do
+        if [[ "$line" =~ :suse:SAPHanaTopology ]] ; then
+           if [[ "$line" =~ SID=(...) ]]; then
+               echo "${BASH_REMATCH[1]}"
+           fi
+        fi
+    done < "$cF"
+done | sort -u | tr '[:upper:]' '[:lower:]' )
+
+#
+####################
+#
+# create a tmp directory to extract pengine files
+#
+if [ -z "$pengine" ]; then
+    mkdir -p "${archive}-tmp/tmp"
+fi
+#
+####################
+# create output directory, if set
+#
+if [ -n "$outDir" ]; then
+   mkdir -p "$outDir"
+   case "$format" in
+       book )
+           rsync -a  /usr/share/SAPHanaSR/icons $outDir
+           ;;
+   esac
+   outNr=0
+fi
+
+
+#
+####################
+#
+# for all sids process all pengine files and show the hana attributes
+#
+for sid in $sids; do
+    echo "================ replay for sid $sid ==============="
+    for cibBZ2 in $pFilesSorted; do
+       cib="${cibBZ2%.bz2}";
+       shortCIB="${cib##*/}"
+       echo "cib: $cib";
+       if [ -z "$pengine" ]; then
+	   cibFile="${archive}-tmp/tmp/$shortCIB"
+           bunzip2 -c "$cibBZ2" > "$cibFile";
+       else
+	   cibFile="$pengine"/"$shortCIB"
+           bunzip2 -c "$cibBZ2" > "$cibFile";
+       fi
+       case "$format" in
+           tables | script )
+               /usr/sbin/SAPHanaSR-showAttr --cib="$cibFile" --sid="$sid" --format="$format";
+                   ;;
+           book )
+               if [ -n "$outDir" ]; then
+                   outOption="--out=$outDir/sapMonitor.$outNr.html"
+                   (( outNr ++ ))
+               fi
+               /usr/sbin/SAPHanaSR-monitor --cib="$cibFile" --sid="$sid" --format="html2" "$outOption";
+                   ;;
+           txt | ascii | html )
+               /usr/sbin/SAPHanaSR-monitor --cib="$cibFile" --sid="$sid" --format="$format"
+                   ;;
+       esac
+       #rm "${archive}-tmp/tmp/$shortCIB" ;
+    done
+    case "$format" in
+        book )
+               if [ -n "$outDir" ]; then
+                  lastFile="$outDir/sapMonitor.$outNr.html"
+                  cat << EOF >$lastFile
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>SAPHanaSR status</title>
+<meta http-equiv="refresh" content="1; url=./sapMonitor.0.html" />
+<meta charset="utf-8"/>
+</head>
+<body class="" style="background-color:#dcddde;">
+</body>
+</html>
+EOF
+               fi
+               ;;
+    esac
+done

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -747,7 +747,7 @@ sub host_attr2string
                     $len = $$refN{$AKey}->{_length};
                     if ( $format eq "tables" ) {
                         $string.=sprintf "%-$len.${len}s ", $$refH{$HKey} -> {$AKey};
-                    } elsif ( $format eq "tables" ) {
+                    } elsif ( $format eq "script" ) {
                         $string.=sprintf "%s/%s/%s=\"%s\"\n", $title, $HKey, $AKey, $$refH{$HKey} -> {$AKey};
                     }
                 }

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -44,8 +44,8 @@ my $cibFile="";
 # H and HName: Hashes for the host specific attributes (objects are host-names)
 # R and RName: Hashes for the resource specific attributes (object are resource-names)
 # S and SName: Hashes for the site specific attributes (objects are site-names)
-# 
-# 
+#
+#
 #
 
 my $refGName;  # reference to GlobalTableKeyName Hash attribute -> object - value
@@ -54,55 +54,55 @@ my $refSName;  # reference to SiteTableKeyName Hash
 my $refRName;  # reference to ResourceTableKeyName Hash
 my $refSite;   # reference to Site-Hash
 
-sub set_Site($)
+sub set_Site
 {
    $refSite=shift();
 }
-sub set_HName($)
+sub set_HName
 {
    $refHName=shift();
 }
-sub set_GName($)
+sub set_GName
 {
    $refGName=shift();
 }
-sub set_RName($)
+sub set_RName
 {
    $refRName=shift();
 }
-sub set_SName($)
+sub set_SName
 {
    $refSName=shift();
 }
 
-sub set_new_attribute_model()
+sub set_new_attribute_model
 {
     $newAttributeModel=1;
 }
 
-sub set_cibFile($)
+sub set_cibFile
 {
     $cibFile=shift();
 }
 
-sub get_new_attribute_model()
+sub get_new_attribute_model
 {
     return $newAttributeModel;
 }
 
-sub max { 
+sub max {
  # thanks to http://www.perlunity.de/perl/forum/thread_018329.shtml
  my $a = shift;
  my $b = shift;
  return $a > $b ? $a : $b;
 }
 
-sub mysyslog ( $$$ ) {
+sub mysyslog {
    my ($prio, $form, @param) = ( @_ );
    syslog $prio, $form, @param;
 }
 
-sub get_nodes_online 
+sub get_nodes_online
 {
     my $result=0;
     my $sid=shift;
@@ -115,7 +115,7 @@ sub get_nodes_online
     return $result;
 }
 
-sub get_node_status($)
+sub get_node_status
 {
     # typically returns online, standby or offline
     # since pacemaker ?? online/offile and standby (on/off) are 2 different attributes
@@ -133,12 +133,12 @@ sub get_node_status($)
     return $result;
 }
 
-sub get_node_list()
+sub get_node_list
 {
     # crm_node -l | awk '$3 == "member" { if ($2 != me) { print $2 }}'
     my @nodes;
     foreach my $h ( keys(%{$$refHName{node_state}}) ) {
-        if ( ! ( $h =~ "^_" )) { 
+        if ( ! ( $h =~ "^_" )) {
             push (@nodes, $h);
         }
     }
@@ -148,7 +148,7 @@ sub get_node_list()
 #
 # works only, if ONE SAPinstance (here HANA) is installed on the cluster
 #
-sub get_sid_and_InstNr()
+sub get_sid_and_InstNr
 {
     my $sid=""; my $Inr=""; my $noDAACount = 0; my $gotAnswer = 0;
     my @sid_ino;
@@ -179,7 +179,7 @@ sub get_sid_and_InstNr()
 
 my $table_title = "Host \\ Attr";
 
-sub insertAttribute($$$$$$) { 
+sub insertAttribute {
     my ($sid, $refHash, $refN, $object, $attribute, $value) = @_;
     my $table_titleH="";
     if ( $attribute =~ /hana_${sid}_(.*)/ ) {
@@ -205,7 +205,7 @@ sub insertAttribute($$$$$$) {
        } else {
           $$refN{$attribute}->{_length} = length($value );
        }
-       $$refN{$attribute}->{_title} = $attribute; 
+       $$refN{$attribute}->{_title} = $attribute;
        $$refN{$attribute}->{_length} = max($$refN{$attribute}->{_length}, length( $$refN{$attribute}->{_title}));
        # printf "%-8s %-20s %-30s\n", $1, $2, $3;
 }
@@ -264,7 +264,7 @@ while (<$CIB>) {
          $id2uname{$nodeID}=$nodeUNAME;
          # printf STDERR "%s -> %s\n", $nodeID, $id2uname{$nodeID};
       }
-   } 
+   }
    #
    #  <nvpair id="nodes-1234567890-standby" name="standby" value="off"/>
    #
@@ -354,11 +354,11 @@ close CIB;
 
 ################
 
-sub get_hana_sync_state($)
+sub get_hana_sync_state
 {
     my $sid=shift;
     my $result="";
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         $result = $$refGName{sync_state}->{"global"};
     } else  {
         foreach my $h ( keys(%{$$refHName{sync_state}}) ) {
@@ -370,10 +370,10 @@ sub get_hana_sync_state($)
     return $result;
 }
 
-sub get_secondary_score($)
+sub get_secondary_score
 {
     my $result="-";
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         foreach my $s ( keys(%{$$refSName{"srr"}}) ) {
 # TODO
             $result="-";
@@ -391,12 +391,12 @@ sub get_secondary_score($)
     return $result;
 }
 
-sub get_number_primary($ $)
+sub get_number_primary
 {
     my $sid=shift;
     my $lss=shift;
     my $rc=0;
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         foreach my $s ( keys(%{$$refSName{"srr"}}) ) {
             if ( ( $$refSName{"srr"}->{$s} =~ /P/ ) && ( $$refSName{"lss"}->{$s} =~ /[$lss]/ )) {
                $rc++;
@@ -412,7 +412,7 @@ sub get_number_primary($ $)
     return $rc;
 }
 
-sub get_number_HANA_standby($$)
+sub get_number_HANA_standby
 {
     my $sid=shift;
     my $site=shift;
@@ -431,7 +431,7 @@ sub get_number_HANA_standby($$)
     return $standby;
 }
 
-sub get_HANA_nodes($$)
+sub get_HANA_nodes
 {
     my $sid=shift;
     my $site=shift;
@@ -442,17 +442,17 @@ sub get_HANA_nodes($$)
             if ( $hSite eq $site ) {
                 push (@nodes, $h);
             }
-        } 
+        }
     }
     return @nodes;
 }
 
-sub check_node_status($$$)
+sub check_node_status
 {
     my $sid=shift;
     my $lss=shift;
     my $h=shift;
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         my $site1=$$refHName{"site"}{$h};
         if ( $$refSName{"lss"}{$site1} =~ /^[$lss]/ ) {
             return 1;
@@ -465,12 +465,12 @@ sub check_node_status($$$)
     return 0;
 }
 
-sub check_node_mode($$$)
+sub check_node_mode
 {
     my $sid=shift;
     my $mode=shift;
     my $h=shift;
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         my $site1=$$refHName{"site"}{$h};
         if ( $$refSName{"srr"}{$site1} =~ /^$mode/ ) {
             return 1;
@@ -483,7 +483,7 @@ sub check_node_mode($$$)
     return 0;
 }
 
-sub get_cluster_status()
+sub get_cluster_status
 {
     my $return="";
     foreach my $h ( keys(%{$$refHName{"node_state"}} )) {
@@ -498,12 +498,12 @@ sub get_cluster_status()
     return $return;
 }
 
-sub get_number_secondary($ $)
+sub get_number_secondary
 {
     my $sid=shift;
     my $lss=shift;
     my $rc=0;
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         foreach my $s ( keys(%{$$refSName{"srr"}}) ) {
             if ( ( $$refSName{"srr"}->{$s} =~ /S/ ) && ( $$refSName{"lss"}->{$s} =~ /[$lss]/ )) {
                $rc++;
@@ -519,12 +519,12 @@ sub get_number_secondary($ $)
     return $rc;
 }
 
-sub get_host_primary($ $)
+sub get_host_primary
 {
     my $sid=shift;
     my $lss=shift;
     my $result="";
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         foreach my $s ( keys(%{$$refSName{"srr"}}) ) {
             if ( ( $$refSName{"srr"}->{$s} =~ /P/ ) && ( $$refSName{"lss"}->{$s} =~ /[$lss]/ )) {
                $result=$$refSName{"mns"}->{$s};
@@ -540,12 +540,12 @@ sub get_host_primary($ $)
     return $result;
 }
 
-sub get_host_secondary($ $)
+sub get_host_secondary
 {
     my $sid=shift;
     my $lss=shift;
     my $result="";
-    if ( $newAttributeModel == 1 ) {    
+    if ( $newAttributeModel == 1 ) {
         foreach my $s ( keys(%{$$refSName{"srr"}}) ) {
             if ( ( $$refSName{"srr"}->{$s} =~ /S/ ) && ( $$refSName{"lss"}->{$s} =~ /[$lss]/ )) {
                $result=$$refSName{"mns"}->{$s};
@@ -561,7 +561,7 @@ sub get_host_secondary($ $)
     return $result;
 }
 
-sub get_site_by_host($ $)
+sub get_site_by_host
 {
     my $result="";
     my $sid=shift;
@@ -571,7 +571,7 @@ sub get_site_by_host($ $)
     return $result;
 }
 
-sub get_lpa_by_host($$)
+sub get_lpa_by_host
 {
     my $result="";
     my $sid=shift;
@@ -589,7 +589,7 @@ sub get_lpa_by_host($$)
 my $check_lpa_msg="";
 my $check_lpa_col="";
 
-sub check_lpa_status($$$)
+sub check_lpa_status
 {
     my $sid=shift;
     my $node1=shift;
@@ -635,7 +635,7 @@ sub check_lpa_status($$$)
     return ( $check_lpa_col, $check_lpa_msg);
 }
 
-sub check_all_ok($$)
+sub check_all_ok
 {
     my $sid=shift;
     my $ClusterNodes=shift;
@@ -644,23 +644,23 @@ sub check_all_ok($$)
     my $result;
     $result=get_nodes_online;
     if ( $result != $ClusterNodes ) {
-         $rc++;  
-         $failed .= " #N=$result"; 
+         $rc++;
+         $failed .= " #N=$result";
     }
     $result=get_hana_sync_state($sid);
     # printf "+++ get_hana_sync_state($sid): %s\n", get_hana_sync_state($sid);
     if ( $result ne "SOK" ) {
-         $rc++;  
+         $rc++;
          $failed .= " sync=$result ";
     }
     $result=get_number_primary($sid, "34");
     if ( $result != 1 ) {
-         $rc++;  
+         $rc++;
          $failed .= " #P=$result ";
     }
     $result=get_number_secondary($sid, "34");
     if ( $result != 1 ) {
-         $rc++;  
+         $rc++;
          $failed .= " #S=$result ";
     }
     $result=get_secondary_score($sid);
@@ -676,7 +676,7 @@ sub check_all_ok($$)
     return ($rc, $failed);
 }
 
-#sub print_attr_host()
+#sub print_attr_host
 #{
 #	printf "%-22s", "Attribute \\ Host";
 #	foreach my $HKey (sort keys %Host) {
@@ -723,7 +723,7 @@ sub host_attr2string
             if ($AKey ne "_hosts") {
                 $len = $$refN{$AKey}->{_length};
                 $line_len=$line_len+$len+1;
-                
+
                 if ( $AKey eq $sort ) {
                    $string.=sprintf "*%-$len.${len}s ", $$refN{$AKey}->{_title};
                 } else {
@@ -755,7 +755,7 @@ sub host_attr2string
             if ( $format eq "tables" ) {
                 $string.=sprintf "\n";
             }
-        }    
+        }
     } else {
        # try to sort by site (other attrs to follow)
        # first try to get a ordered list of attribute values assigned host names
@@ -783,7 +783,7 @@ sub host_attr2string
            #printf "TST: <%s> -> <%s>\n", $sortV, $StrHosts;
        }
     }
-    
+
     if ( $format eq "tables" ) {
 	    $string.=sprintf "\n";
     }
@@ -804,11 +804,11 @@ sub print_host_attr
     return 0;
 }
 
-sub get_master_nameserver()
+sub get_master_nameserver
 {
     my @msns;
     foreach my $SKey (sort keys %$refSite) {
-        push(@msns, $$refSite{$SKey}->{"mns"}); 
+        push(@msns, $$refSite{$SKey}->{"mns"});
     }
     return @msns;
 }

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -696,44 +696,64 @@ sub check_all_ok($$)
 #	return 0;
 #}
 
-sub host_attr2string($$$$)
+sub host_attr2string
 {
     my $string="";
-    my ($refH, $refN, $title, $sort) = @_;
+    my ($refH, $refN, $title, $sort, $format) = @_;
     my ($len, $line_len, $hclen);
-    $hclen=$$refN{_hosts}->{_length};
-    $line_len=$hclen+1;
-    $string.=sprintf "%-$hclen.${hclen}s ", "$title";
     #
-    # headline
+    # leave function if hash is empty
+    #    in this case an empty string is returned
     #
-    foreach my $AKey (sort keys %$refN) {
-        if ($AKey ne "_hosts") {
-            $len = $$refN{$AKey}->{_length};
-            $line_len=$line_len+$len+1;
-            
-            if ( $AKey eq $sort ) {
-               $string.=sprintf "*%-$len.${len}s ", $$refN{$AKey}->{_title};
-            } else {
-               $string.=sprintf "%-$len.${len}s ", "$$refN{$AKey}->{_title}";
-            }
-        }
+    if ( ! ( keys %$refN )) {
+       return "";
     }
-    $string.=sprintf "\n";
-    $string.=sprintf "%s\n", "-" x $line_len ;
+    if ( ! defined $format) {
+        $format="tables"
+    }
+    if ( $format eq "tables" ) {
+	    $hclen=$$refN{_hosts}->{_length};
+	    $line_len=$hclen+1;
+	    $string.=sprintf "%-$hclen.${hclen}s ", "$title";
+        #
+        # headline
+        #
+        foreach my $AKey (sort keys %$refN) {
+            if ($AKey ne "_hosts") {
+                $len = $$refN{$AKey}->{_length};
+                $line_len=$line_len+$len+1;
+                
+                if ( $AKey eq $sort ) {
+                   $string.=sprintf "*%-$len.${len}s ", $$refN{$AKey}->{_title};
+                } else {
+                   $string.=sprintf "%-$len.${len}s ", "$$refN{$AKey}->{_title}";
+                }
+            }
+	    }
+	    $string.=sprintf "\n";
+	    $string.=sprintf "%s\n", "-" x $line_len ;
+    }
     #
     # object / name / value lines
     #
     if ( $sort eq "" ) {
         foreach my $HKey (sort keys %$refH) {
-            $string.=sprintf "%-$hclen.${hclen}s ", $HKey;
+            if ( $format eq "tables" ) {
+                $string.=sprintf "%-$hclen.${hclen}s ", $HKey;
+            }
             foreach my $AKey (sort keys %$refN) {
                 if ($AKey ne "_hosts") {
                     $len = $$refN{$AKey}->{_length};
-                    $string.=sprintf "%-$len.${len}s ", $$refH{$HKey} -> {$AKey};
+                    if ( $format eq "tables" ) {
+                        $string.=sprintf "%-$len.${len}s ", $$refH{$HKey} -> {$AKey};
+                    } elsif ( $format eq "tables" ) {
+                        $string.=sprintf "%s/%s/%s=\"%s\"\n", $title, $HKey, $AKey, $$refH{$HKey} -> {$AKey};
+                    }
                 }
             }
-            $string.=sprintf "\n";
+            if ( $format eq "tables" ) {
+                $string.=sprintf "\n";
+            }
         }    
     } else {
        # try to sort by site (other attrs to follow)
@@ -762,17 +782,24 @@ sub host_attr2string($$$$)
            #printf "TST: <%s> -> <%s>\n", $sortV, $StrHosts;
        }
     }
-    $string.=sprintf "\n";
+    
+    if ( $format eq "tables" ) {
+	    $string.=sprintf "\n";
+    }
     return $string;
 }
 
-sub print_host_attr($$$$)
+sub print_host_attr
 {
     my $string="";
-    my ($refH, $refN, $title, $sort) = @_;
-    my ($AKey, $HKey, $len, $line_len, $hclen);
-
-    printf "%s\n", host_attr2string($refH, $refN, $title, $sort);
+    my ($refH, $refN, $title, $sort, $format) = @_;
+    if ( ! defined $format) {
+        $format="tables"
+    }
+    my $print_attributes_result = host_attr2string($refH, $refN, $title, $sort, $format);
+    if ( $print_attributes_result ) {
+        printf "%s", $print_attributes_result;
+    }
     return 0;
 }
 

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -267,15 +267,15 @@ while (<$CIB>) {
    #
    #  <nvpair id="nodes-1234567890-standby" name="standby" value="off"/>
    #
-   if ( $_ =~ /id="nodes-(.+)-standby"/ ) {
-       my $host=$1;
+   if ( $_ =~ /id="nodes-(.+)-(standby|maintenance)"/ ) {
+       my $host=$1; my $attribute=$2;
          if (defined $id2uname{$host}) {
              $host = $id2uname{$host}
          }
        if ( $_ =~ /value="([a-zA-Z0-9\-\_]+)"/ ) {
            my $value=$1;
 #printf "STANDBY <%s> VALUE <%s>\n", $host, $value;
-           insertAttribute($sid, $refHH, $refHN, $host, "standby", $value);
+           insertAttribute($sid, $refHH, $refHN, $host, $attribute, $value);
        }
    }
    #

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -5,7 +5,7 @@
 # (c) 2015-2018 SUSE Linux GmbH
 # Author: Fabian Herschel
 # License: Check if we publish that under GPL v2+
-# Version: 0.23.2018.05.11.1
+# Version: 0.24.0708.0936
 #
 ##################################################################
 

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -65,6 +65,10 @@ sub set_GName($)
 {
    $refGName=shift();
 }
+sub set_RName($)
+{
+   $refRName=shift();
+}
 sub set_SName($)
 {
    $refSName=shift();
@@ -205,9 +209,9 @@ sub insertAttribute($$$$$$) {
        # printf "%-8s %-20s %-30s\n", $1, $2, $3;
 }
 ################
-sub get_hana_attributes($$$$$$$)
+sub get_hana_attributes
 {
-    my ($sid, $refHH, $refHN, $refGL, $refGN, $refST, $refSN ) = @_;
+    my ($sid, $refHH, $refHN, $refGL, $refGN, $refST, $refSN, $refRL, $refRN ) = @_;
     my %id2uname;
     my $CIB;
     if ( $cibFile eq "" ) {
@@ -222,6 +226,28 @@ while (<$CIB>) {
       # printf "CIB-time: %s\n", $1;
       insertAttribute($sid, $refGL, $refGN, "global", "cib-time", $1);
    }
+
+   # search for is-managed and maintenance attributes
+   my $id, $value;
+    if ( / name=\"?(is-managed|maintenance)\"?/ ) {
+       $name = $1;
+       if ( / id="([^\"]*)"/ ) {
+           $id=$1;
+           if ( $id =~ /([^-]*)-/ ) {
+		   $id=$1;
+           }
+       }
+       if ( / value="([^\"]*)"/ ) {
+           $value=$1;
+       }
+      if ( $id eq "cib" ) {
+	      insertAttribute($sid, $refGL, $refGN, "global", "$name", "$value");
+      } elsif ( $id eq "nodes" ) {
+              # to be processed in node section (below)
+      } else {
+	      insertAttribute($sid, $refRL, $refRN, "$id", "$name", "$value");
+      }
+    }
    my $SID=uc($sid);
    if ( $_ =~ /<node / ) {
       # catch a node definition line

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -1,11 +1,12 @@
 #
 #
 # SAPHanaSRTools.pm
-# (c) 2014 SUSE Linux Products GmbH
-# (c) 2015-2018 SUSE Linux GmbH
+# Copyright:    (c) 2014 SUSE Linux Products GmbH
+# Copyright:    (c) 2015-2016 SUSE Linux GmbH
+# Copyright:    (c) 2017-2020 SUSE LLC
 # Author: Fabian Herschel
 # License: Check if we publish that under GPL v2+
-# Version: 0.24.0708.0936
+# Version: 0.24.0709.1005
 #
 ##################################################################
 

--- a/SAPHana/test/SAPHanaSRTools.pm
+++ b/SAPHana/test/SAPHanaSRTools.pm
@@ -31,10 +31,27 @@ my $cibFile="";
 
 #    @EXPORT_OK    = qw(max  mysyslog get_nodes_online);
 
-my $refGName;
-my $refHName;
-my $refSName;
-my $refSite;
+# The X-Hashes     contain the structure OBJECT -> ATTRIBUTE (KEY) - VALUE
+# The XName-Hashes contain the structure ATTRIBUTE (KEY -> OBJECT - VALUE
+#
+# Depending on the hashes OBJECT could be "global", node-name, site-name, resource-id
+# ATTRIBUTES could be clone_state, srHook
+#
+# There are xxx types of hashes:
+#
+# G and GName: Hashes for global attribues (object is always "global")
+# H and HName: Hashes for the host specific attributes (objects are host-names)
+# R and RName: Hashes for the resource specific attributes (object are resource-names)
+# S and SName: Hashes for the site specific attributes (objects are site-names)
+# 
+# 
+#
+
+my $refGName;  # reference to GlobalTableKeyName Hash attribute -> object - value
+my $refHName;  # reference to HostTableKeyName Hash
+my $refSName;  # reference to SiteTableKeyName Hash
+my $refRName;  # reference to ResourceTableKeyName Hash
+my $refSite;   # reference to Site-Hash
 
 sub set_Site($)
 {


### PR DESCRIPTION
This PR is to sync the first part of patches for
- block-srTakeover: The idea is to differ manual from cluster-automated sr_takeover() calls. 
  This feature needs a special (additional) SAP HA/DR hook script (python) and an updated resource agent SAPHanaController
- saphanasr-toolset: get the improved scale-up tool-set available for scale-out